### PR TITLE
Fixed innerHTML assignment for <span> elements

### DIFF
--- a/src/ie-behavior-span.js
+++ b/src/ie-behavior-span.js
@@ -264,6 +264,8 @@
 			if (props.hasOwnProperty(i)) {
 				if (i === 'style') {
 					setStyle(elem, props[i]);
+				} else if (i === 'innerHTML') {
+					elem.innerHTML = props[i];
 				} else {
 					elem.setAttribute(i, props[i]);
 				}

--- a/src/span.js
+++ b/src/span.js
@@ -321,6 +321,8 @@
 			if (props.hasOwnProperty(i)) {
 				if (i === 'style') {
 					setStyle(elem, props[i]);
+				} else if (i === 'innerHTML') {
+					elem.innerHTML = props[i];
 				} else {
 					elem.setAttribute(i, props[i]);
 				}


### PR DESCRIPTION
In the both `*span.js` variants, the `innerHTML` of the created `<span>` elements isn't set properly. Instead, an `innerHTML` attribute gets created, which leads to the the placeholder-`<span>` not being visible (as it is empty). It gets visible though after it's been redrawn for the first time (e.g. focused and unfocused once).

I fixed this by explicitly treating the `innerHTML` property.

_Observed with IE11 in IE9 mode._
