### PR TITLE
Fix issue tabbing between inputs

### DIFF
--- a/src/ie-behavior-span.js
+++ b/src/ie-behavior-span.js
@@ -99,9 +99,9 @@
 			redrawPlaceholder();
 		}
 
-		function checkPlaceholder() {
+		function checkPlaceholder(event) {
 			if (elem.value) {
-				hidePlaceholder();
+				hidePlaceholder(event, event.type === 'blur');
 			} else {
 				showPlaceholder();
 			}
@@ -113,11 +113,13 @@
 			addClass(elem, '-placeholder-input');
 		}
 
-		function hidePlaceholder() {
+		function hidePlaceholder(event, suppressFocus) {
 			placeholder.style.display = 'none';
 			removeClass(placeholder, '-placeholder');
 			removeClass(elem, '-placeholder-input');
-			elem.focus();
+			if(! suppressFocus) {
+        elem.focus();
+      }
 		}
 	}
 

--- a/src/span.js
+++ b/src/span.js
@@ -139,9 +139,9 @@
 			redrawPlaceholder();
 		}
 
-		function checkPlaceholder() {
+		function checkPlaceholder(event) {
 			if (elem.value) {
-				hidePlaceholder();
+				hidePlaceholder(event, event.type === 'blur');
 			} else {
 				showPlaceholder();
 			}
@@ -153,11 +153,13 @@
 			addClass(elem, '-placeholder-input');
 		}
 
-		function hidePlaceholder() {
+		function hidePlaceholder(event, suppressFocus) {
 			placeholder.style.display = 'none';
 			removeClass(placeholder, '-placeholder');
 			removeClass(elem, '-placeholder-input');
-			elem.focus();
+			if(! suppressFocus) {
+        elem.focus();
+      }
 		}
 	}
 


### PR DESCRIPTION
Bug: Click on an input, type something, click on another input; focus is left on
the first input.

I added a quick check so that `elem.focus()` will not be called for blur events.
