### PR TITLE
"undefined" is shown as placeholder

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -259,7 +259,7 @@
 	// Internet Explorer 10 in IE7 mode was giving me the wierest error
 	// where e.getAttribute('placeholder') !== e.attributes.placeholder.nodeValue
 	function getPlaceholderFor(elem) {
-		return elem.getAttribute('placeholder') || (elem.attributes.placeholder && elem.attributes.placeholder.nodeValue);
+		return elem.getAttribute('placeholder') || (elem.attributes.placeholder && elem.attributes.placeholder.nodeValue) || '';
 	}
 
 // -------------------------------------------------------------


### PR DESCRIPTION
When the element doesn't have any placeholder attribute, "undefined" was shown. With this fallback no placeholder is visible, which is correct.
