### PR TITLE
Fixes both 'type' is null and 'regexCache' is null 

### DIFF
--- a/demos/span-bugtests.html
+++ b/demos/span-bugtests.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+<head>
+	<title>Placeholder Demo (Span) for bug fixes</title>
+	<style type="text/css">
+
+		* {
+			font-family: sans-serif;
+			font-size: 16px;
+		}
+
+		input[type=text],
+		button {
+			display: block;
+			margin: 10px;
+			padding: 4px;
+			border: 2px #ccc solid;
+			border-radius: 4px;
+		}
+
+	</style>
+</head>
+<body>
+	<h1>Placeholder Polyfill Demo (span.js) bugtests</h1>
+
+	<div id="inputs">
+		<input type="text" value="" placeholder="First" />
+		<input type="text" value="" placeholder="Second" />
+                <!-- Test Issue #9 -->
+		<input type="text" value="Value" placeholder="Third" />
+                <!-- Test "undefined" text issue - on input without placeholder -->
+		<input type="text" value=""/>
+	</div>
+
+	<button id="add-input">Add Input</button>
+
+	<script type="text/javascript" src="../src/span.js"></script>
+	<script type="text/javascript">
+
+		var inputs = document.getElementById('inputs');
+		var addButton = document.getElementById('add-input');
+
+		addButton.onclick = function() {
+			var input = document.createElement('input');
+			input.type = 'text';
+			input.placeholder = 'New Input';
+			inputs.appendChild(input);
+			document.placeholderPolyfill(input);
+		};
+
+	</script>
+</body>
+</html>

--- a/demos/span-bugtests.html
+++ b/demos/span-bugtests.html
@@ -26,10 +26,11 @@
 	<div id="inputs">
 		<input type="text" value="" placeholder="First" />
 		<input type="text" value="" placeholder="Second" />
-                <!-- Test Issue #9 -->
+                <!-- Test Issue #9 and regexCache problem-->
 		<input type="text" value="Value" placeholder="Third" />
                 <!-- Test "undefined" text issue - on input without placeholder -->
-		<input type="text" value=""/>
+		<input type="text" value="XYZ"/>
+                <textarea id="RichText" name="Body" rows="16" cols="78" wrap="off"></textarea>
 	</div>
 
 	<button id="add-input">Add Input</button>

--- a/src/span.js
+++ b/src/span.js
@@ -141,7 +141,11 @@
 
 		function checkPlaceholder(event) {
 			if (elem.value) {
-				hidePlaceholder(event, event.type === 'blur');
+                                var nofocus = true;
+                                if (event && event.type ){
+                                      nofocus = event.type === 'blur';
+                                }
+                                hidePlaceholder(event, nofocus);
 			} else {
 				showPlaceholder();
 			}

--- a/src/span.js
+++ b/src/span.js
@@ -6,6 +6,8 @@
 // 
 
 (function(window, document, undefined) {
+        // MSIE8 does not allow vars between functions...
+	var regexCache = { };
 
 	// Don't run the polyfill if it isn't needed
 	if ('placeholder' in document.createElement('input')) {
@@ -241,7 +243,6 @@
 
 // -------------------------------------------------------------
 
-	var regexCache = { };
 	function classNameRegex(cn) {
 		if (! regexCache[cn]) {
 			regexCache[cn] = new RegExp('(^|\\s)+' + cn + '(\\s|$)+', 'g');


### PR DESCRIPTION
Hello!

This pull request fixes two issues for MSIE8 (and possibly others):
- _'type' is null or not an object_ - Issue #9 
- _'regexCache' is null or not an object_ - this seem to be specific MSIE8 behaviour (it does not allow closure var declaration between function bodies???)
